### PR TITLE
fix: Register "app.css"

### DIFF
--- a/app/loadCss.ts
+++ b/app/loadCss.ts
@@ -2,6 +2,7 @@ const application = require("tns-core-modules/application");
 require("tns-core-modules/ui/styling/style-scope");
 
 global.registerModule("./app.css", () => require("~/app1.css"));
+global.registerModule("app.css", () => require("~/app1.css"));
 
 application.loadAppCss();
 


### PR DESCRIPTION
Register `"app.css"` as well as `"./app.css"`. 

Related to https://github.com/NativeScript/nativescript-dev-webpack/pull/1016 and  https://github.com/NativeScript/NativeScript/pull/7631